### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_dynamodb_alt.rb
+++ b/lib/fluent/plugin/out_dynamodb_alt.rb
@@ -10,8 +10,8 @@ class Fluent::DynamodbAltOutput < Fluent::BufferedOutput
 
   config_param :profile,              :string,  :default => nil
   config_param :credentials_path,     :string,  :default => nil
-  config_param :aws_key_id,           :string,  :default => nil
-  config_param :aws_sec_key,          :string,  :default => nil
+  config_param :aws_key_id,           :string,  :default => nil, :secret => true
+  config_param :aws_sec_key,          :string,  :default => nil, :secret => true
   config_param :region,               :string,  :default => nil
   config_param :endpoint,             :string,  :default => nil
   config_param :table_name,           :string


### PR DESCRIPTION
`aws_key_id` and `aws_sec_key` contain sensitive information.
These parameters should be concealed with secret parameter feature.
