### PR TITLE
AWS sdk to stick to v2

### DIFF
--- a/fluent-plugin-dynamodb-alt.gemspec
+++ b/fluent-plugin-dynamodb-alt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '>= 2.0.0.rc15'
+  spec.add_dependency 'aws-sdk-core', '~> 2'
   spec.add_dependency 'parallel'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Hi @winebarrel,

Currently the plugin will install aws-sdk-core v3. I want to avoid it.